### PR TITLE
fix - downgrade version for easier pipeline - quick

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as base
+FROM golang:1.16 as base
 
 FROM base as dev
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module test/rulette_rousse
 
-go 1.22
+go 1.16


### PR DESCRIPTION
there were problems with the go version 1.22 with the hotreloading of the air command